### PR TITLE
Feature/marketing permissions for checkout and my acocunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,4 @@ Installation for the Custobar WooCommerce Plugin is the same as any other WordPr
 
 - Order totals include VAT but order items do not (this is the default functionality of WooCommerce)
 
-- Permission for marketing is asked in the checkout phase only for unauthenticated users. Usually customer do not register before the first order so practically this is rarely a problem. Permission is not given if it's not asked. This functionality might have to be changed if you offer a path to registration without purchase.
-
-- Permission for marketing sets _email_ and _sms_ permissions if selected. No functionality to edit this through filters at this point.
+- This plugin adds support for Custobar marketing permissions. The plugin also adds a Rest API endpoint that allows syncing marketing permissions from Custobar to WooCommerce. Please contact Custobar for further information on how to configure the needed webhook in Custobar.

--- a/assets/custobar.admin.css
+++ b/assets/custobar.admin.css
@@ -1,30 +1,16 @@
-#custobar-settings button {
-  font-size:14px;
-  padding: 8px 14px;
-}
-
-#custobar-settings table {
+.custobar-sync-report {
   border-collapse: collapse;
 }
 
-#custobar-settings table button {
-  padding: 10px 16px;
-  font-size: 16px;
-}
-
-#custobar-settings th,
-#custobar-settings td {
+.custobar-sync-report th,
+.custobar-sync-report td {
   font-size: 14px;
   padding: 12px 10px;
   margin: 0;
 }
 
-#custobar-settings thead tr {
+.custobar-sync-report thead tr {
   background: #D1D1D1;
-}
-
-#custobar-settings td {
-  font-size: 18px;
 }
 
 #custobar-export-wrap {
@@ -50,7 +36,7 @@
  *
  */
 #custobar-api-connection-test-wrap {
-  margin:25px 0 45px;
+  margin: 25px 0 45px;
 }
 #custobar-api-connection-test-wrap hr {
   margin: 30px 0 30px;

--- a/assets/custobar.admin.js
+++ b/assets/custobar.admin.js
@@ -64,8 +64,12 @@
 
 		var _post = function () {
 			var resetCheck = $('input[name="reset-' + recordType + '"]');
-			var emailPermissionCheck = $('input[name="can-email-' + recordType + '"]');
-			var smsPermissionCheck = $('input[name="can-sms-' + recordType + '"]');
+			var emailPermissionCheck = $(
+				'input[name="can-email-' + recordType + '"]'
+			);
+			var smsPermissionCheck = $(
+				'input[name="can-sms-' + recordType + '"]'
+			);
 
 			data = {
 				action: "custobar_export",
@@ -120,7 +124,14 @@
 				}
 				if (response.code == 420) {
 					message +=
-						"Either WooCommerce is uninstalled or other configuration conditions were not met. Check that you have a valid API key set for Custobar. Response code " +
+						"Either WooCommerce is uninstalled or other configuration conditions were not met. " +
+						"Check that you have a valid API key set for Custobar. Response code " +
+						response.code +
+						", no records were exported.";
+				}
+				if (response.code == 429) {
+					message +=
+						"Too many requests. Response code " +
 						response.code +
 						", no records were exported.";
 				}
@@ -129,6 +140,10 @@
 						"No more records available to export. Response code " +
 						response.code +
 						", no records were exported.";
+				}
+				if (response.code == 444) {
+					message +=
+						"Error connecting to Custobar API: " + response.body;
 				}
 
 				$("#custobar-export-wrap table tr.response td").html(message);

--- a/assets/custobar.admin.js
+++ b/assets/custobar.admin.js
@@ -56,7 +56,7 @@
 
 		if (!responseCell.length) {
 			$("#custobar-export-wrap table").append(
-				'<tr class="response"><td colspan="7">' + message + "</td></tr>"
+				'<tr class="response"><td colspan="9">' + message + "</td></tr>"
 			);
 		} else {
 			responseCell.html(message);
@@ -64,6 +64,8 @@
 
 		var _post = function () {
 			var resetCheck = $('input[name="reset-' + recordType + '"]');
+			var emailPermissionCheck = $('input[name="can-email-' + recordType + '"]');
+			var smsPermissionCheck = $('input[name="can-sms-' + recordType + '"]');
 
 			data = {
 				action: "custobar_export",
@@ -74,6 +76,14 @@
 			if (resetCheck.is(":checked")) {
 				data["reset"] = 1;
 				resetCheck.prop("checked", false);
+			}
+
+			if (emailPermissionCheck.is(":checked")) {
+				data["can_email"] = 1;
+			}
+
+			if (smsPermissionCheck.is(":checked")) {
+				data["can_sms"] = 1;
 			}
 
 			$.post(ajaxurl, data, function (response) {

--- a/classes/class-data-upload.php
+++ b/classes/class-data-upload.php
@@ -45,10 +45,15 @@ class Data_Upload {
 		$response_data->body = $response_body;
 
 		// do wc logging
-		if ( ! in_array( $response_code, array( 200, 201 ) ) || is_wp_error( $response_body ) ) {
+		if ( ! in_array( $response_code, array( 200, 201 ) ) || is_wp_error( $response ) ) {
+
+			$message = '';
+			if ( is_wp_error( $response ) ) {
+				$message = ', error message: ' . $response->get_error_message();
+			}
 
 			wc_get_logger()->warning(
-				"Custobar data upload failed. code: $response_code",
+				"Custobar data upload failed. Response code: $response_code $message",
 				array(
 					'source' => 'custobar',
 				)

--- a/classes/class-data-upload.php
+++ b/classes/class-data-upload.php
@@ -16,9 +16,14 @@ use WooCommerceCustobar\Synchronization\Sale_Sync;
 class Data_Upload {
 
 
+	/**
+	 * Do the request to Custobar API
+	 *
+	 * @param string $endpoint
+	 * @param array $data
+	 * @return mixed response object or WP_Error
+	 */
 	public static function upload_custobar_data( $endpoint, $data ) {
-
-		$response_data = new \stdClass();
 
 		$body           = wp_json_encode( $data );
 		$api_token      = \WC_Admin_Settings::get_option( 'custobar_api_setting_token', false );
@@ -37,32 +42,33 @@ class Data_Upload {
 			)
 		);
 
-		$response_code = wp_remote_retrieve_response_code( $response );
-		$response_body = wp_remote_retrieve_body( $response );
-
-		// form response data
-		$response_data->code = $response_code;
-		$response_data->body = $response_body;
-
-		// do wc logging
-		if ( ! in_array( $response_code, array( 200, 201 ) ) || is_wp_error( $response ) ) {
-
-			$message = '';
-			if ( is_wp_error( $response ) ) {
-				$message = ', error message: ' . $response->get_error_message();
-			}
+		// Failed request, do logging and return error object
+		if ( is_wp_error( $response ) ) {
+			$message = $response->get_error_message();
 
 			wc_get_logger()->warning(
-				"Custobar data upload failed. Response code: $response_code $message",
-				array(
-					'source' => 'custobar',
-				)
+				"Custobar data upload failed: $message",
+				array( 'source' => 'custobar' )
+			);
+
+			return $response;
+		}
+
+		// Create a simpler response object
+		$response_data       = new \stdClass();
+		$response_data->code = wp_remote_retrieve_response_code( $response );
+		$response_data->body = wp_remote_retrieve_body( $response );
+
+		// Unexpected response code, do logging
+		if ( ! in_array( $response_data->code, array( 200, 201 ) ) ) {
+
+			wc_get_logger()->warning(
+				"Custobar data upload: Unexpected response code: {$response_data->code}",
+				array( 'source' => 'custobar' )
 			);
 		}
 
-		// return response
 		return $response_data;
-
 	}
 
 	public static function add_hooks() {

--- a/classes/class-data-upload.php
+++ b/classes/class-data-upload.php
@@ -70,6 +70,11 @@ class Data_Upload {
 		add_action( 'wp_ajax_custobar_api_test', __CLASS__ . '::api_test' );
 	}
 
+	/**
+	 * Historical data sync callback
+	 *
+	 * @return void
+	 */
 	public static function jx_export() {
 		// environment checks
 		$plugin = new Plugin();

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -33,35 +33,6 @@ class Plugin {
 			Sale_Sync::add_hooks();
 			Data_Upload::add_hooks();
 
-			// Marketing permission
-			// add_action('woocommerce_after_checkout_registration_form', [__CLASS__, 'ask_permission_for_marketing']);
-			// add_action('woocommerce_checkout_update_order_meta', [__CLASS__, 'save_permission_for_marketing']);
-		}
-	}
-
-	/**
-	 * Adds a checkbox field to the checkout asking for permissions for
-	 * marketing.
-	 */
-	public static function ask_permission_for_marketing( $checkout ) {
-		woocommerce_form_field(
-			'marketing_permission',
-			array(
-				'type'  => 'checkbox',
-				'class' => array( 'input-checkbox' ),
-				'label' => apply_filters(
-					'woocommerce_custobar_marketing_permission_text',
-					__( 'I would like to receive marketing messages', 'woocommerce-custobar' )
-				),
-			),
-			$checkout->get_value( 'marketing_permission' )
-		);
-	}
-
-	public static function save_permission_for_marketing( $order_id ) {
-		if ( isset( $_POST['marketing_permission'] ) && $_POST['marketing_permission'] ) {
-			update_post_meta( $order_id, '_woocommerce_custobar_can_email', esc_attr( $_POST['marketing_permission'] ) );
-			update_post_meta( $order_id, '_woocommerce_custobar_can_sms', esc_attr( $_POST['marketing_permission'] ) );
 		}
 	}
 

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -116,7 +116,7 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 				'name' => __( 'Field Mapping', 'woocommerce-custobar' ),
 				'type' => 'title',
 			),
-			self::CUSTOMER_FIELDS => array(
+			self::CUSTOMER_FIELDS      => array(
 				'name'              => __( 'Customer Field Map', 'woocommerce-custobar' ),
 				'type'              => 'textarea',
 				'desc'              => '',
@@ -127,7 +127,7 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 				'class'             => 'input-text wide-input',
 				'id'                => self::CUSTOMER_FIELDS,
 			),
-			self::PRODUCT_FIELDS  => array(
+			self::PRODUCT_FIELDS       => array(
 				'name'              => __( 'Product Field Map', 'woocommerce-custobar' ),
 				'type'              => 'textarea',
 				'desc'              => '',
@@ -138,7 +138,7 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 				'class'             => 'input-text wide-input',
 				'id'                => self::PRODUCT_FIELDS,
 			),
-			self::SALE_FIELDS => array(
+			self::SALE_FIELDS          => array(
 				'name'              => __( 'Sale Field Map', 'woocommerce-custobar' ),
 				'type'              => 'textarea',
 				'desc'              => '',
@@ -149,7 +149,7 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 				'class'             => 'input-text wide-input',
 				'id'                => self::SALE_FIELDS,
 			),
-			'section_end'         => array(
+			'section_end'              => array(
 				'type' => 'sectionend',
 				'id'   => 'custobar_section_end',
 			),

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -62,13 +62,15 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 	public function save() {
 		woocommerce_update_options( $this->get_settings_api() );
 		woocommerce_update_options( $this->get_settings_fields() );
+		woocommerce_update_options( $this->get_settings_marketing() );
 	}
 
 
 	/**
-	 * Get all the settings for this plugin for @see woocommerce_admin_fields() function.
+	 * Get API settings
 	 *
-	 * @return array Array of settings for @see woocommerce_admin_fields() function.
+	 * @see woocommerce_admin_fields() function.
+	 * @return array Array of settings
 	 */
 	public function get_settings_api() {
 
@@ -102,9 +104,10 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 	}
 
 	/**
-	 * Get all the settings for this plugin for @see woocommerce_admin_fields() function.
+	 * Get field map settings
 	 *
-	 * @return array Array of settings for @see woocommerce_admin_fields() function.
+	 * @see woocommerce_admin_fields() function.
+	 * @return array Array of settings
 	 */
 	public function get_settings_fields() {
 
@@ -113,7 +116,7 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 				'name' => __( 'Field Mapping', 'woocommerce-custobar' ),
 				'type' => 'title',
 			),
-			self::CUSTOMER_FIELDS      => array(
+			self::CUSTOMER_FIELDS => array(
 				'name'              => __( 'Customer Field Map', 'woocommerce-custobar' ),
 				'type'              => 'textarea',
 				'desc'              => '',
@@ -124,7 +127,7 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 				'class'             => 'input-text wide-input',
 				'id'                => self::CUSTOMER_FIELDS,
 			),
-			self::PRODUCT_FIELDS       => array(
+			self::PRODUCT_FIELDS  => array(
 				'name'              => __( 'Product Field Map', 'woocommerce-custobar' ),
 				'type'              => 'textarea',
 				'desc'              => '',
@@ -135,7 +138,7 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 				'class'             => 'input-text wide-input',
 				'id'                => self::PRODUCT_FIELDS,
 			),
-			self::SALE_FIELDS          => array(
+			self::SALE_FIELDS => array(
 				'name'              => __( 'Sale Field Map', 'woocommerce-custobar' ),
 				'type'              => 'textarea',
 				'desc'              => '',
@@ -146,7 +149,44 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 				'class'             => 'input-text wide-input',
 				'id'                => self::SALE_FIELDS,
 			),
-			'section_end'              => array(
+			'section_end'         => array(
+				'type' => 'sectionend',
+				'id'   => 'custobar_section_end',
+			),
+		);
+
+		return $settings;
+
+	}
+
+	/**
+	 * Get marketing settings
+	 *
+	 * @see woocommerce_admin_fields() function.
+	 * @return array Array of settings
+	 */
+	public function get_settings_marketing() {
+
+		$settings = array(
+			'custobar_marketing_settings' => array(
+				'name' => __( 'Marketing Settings', 'woocommerce-custobar' ),
+				'type' => 'title',
+				'desc' => '',
+				'id'   => 'custobar_marketing_settings',
+			),
+			'custobar_initial_can_email'  => array(
+				'name' => __( 'Initial email permission', 'woocommerce-custobar' ),
+				'type' => 'checkbox',
+				'desc' => __( 'Set can_email to "true" when exporting a new customer.', 'woocommerce-custobar' ),
+				'id'   => 'custobar_initial_can_email',
+			),
+			'custobar_initial_can_sms'    => array(
+				'name' => __( 'Initial SMS permission', 'woocommerce-custobar' ),
+				'type' => 'checkbox',
+				'desc' => __( 'Set can_sms to "true" when exporting a new customer.', 'woocommerce-custobar' ),
+				'id'   => 'custobar_initial_can_sms',
+			),
+			'section_end'                 => array(
 				'type' => 'sectionend',
 				'id'   => 'custobar_section_end',
 			),
@@ -192,6 +232,8 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 			WC_Admin_Settings::output_fields( $this->get_settings_api() );
 
 		} else {
+
+			WC_Admin_Settings::output_fields( $this->get_settings_marketing() );
 
 			WC_Admin_Settings::output_fields( $this->get_settings_fields() );
 

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -174,18 +174,6 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 				'desc' => '',
 				'id'   => 'custobar_marketing_settings',
 			),
-			'custobar_initial_can_email'  => array(
-				'name' => __( 'Initial email permission', 'woocommerce-custobar' ),
-				'type' => 'checkbox',
-				'desc' => __( 'Set can_email to "true" when exporting a new customer.', 'woocommerce-custobar' ),
-				'id'   => 'custobar_initial_can_email',
-			),
-			'custobar_initial_can_sms'    => array(
-				'name' => __( 'Initial SMS permission', 'woocommerce-custobar' ),
-				'type' => 'checkbox',
-				'desc' => __( 'Set can_sms to "true" when exporting a new customer.', 'woocommerce-custobar' ),
-				'id'   => 'custobar_initial_can_sms',
-			),
 			'section_end'                 => array(
 				'type' => 'sectionend',
 				'id'   => 'custobar_section_end',

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -60,11 +60,22 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 	 * @uses self::get_settings_api()
 	 */
 	public function save() {
-		woocommerce_update_options( $this->get_settings_api() );
-		woocommerce_update_options( $this->get_settings_fields() );
-		woocommerce_update_options( $this->get_settings_marketing() );
-	}
+		// _$POST object is used directly by WC_Admin_Settings::save_fields()
+		$data = $_POST; //phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( empty( $data ) ) {
+			return false;
+		}
+		// Regenerate custobar_wc_rest_api_secret if it does not exist or if reset requested by user.
+		if ( isset( $data['custobar_wc_rest_api_secret'] ) && ( ! $data['custobar_wc_rest_api_secret'] || ! empty( $data['custobar_wc_rest_api_secret_reset'] ) ) ) {
+			$data['custobar_wc_rest_api_secret'] = $this->generate_secret_key();
+			// Unset reset checkbox. We don't need to (and should not) save it.
+			unset( $data['custobar_wc_rest_api_secret_reset'] );
+		}
 
+		woocommerce_update_options( $this->get_settings_api(), $data );
+		woocommerce_update_options( $this->get_settings_fields(), $data );
+		woocommerce_update_options( $this->get_settings_marketing(), $data );
+	}
 
 	/**
 	 * Get API settings
@@ -75,25 +86,41 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 	public function get_settings_api() {
 
 		$settings = array(
-			'custobar_api_settings' => array(
+			'custobar_api_settings'          => array(
 				'name' => __( 'Custobar API Settings', 'woocommerce-custobar' ),
 				'type' => 'title',
 				'desc' => '',
 				'id'   => 'custobar_api_settings',
 			),
-			'custobar_api_token'    => array(
+			'custobar_api_token'             => array(
 				'name' => __( 'API Token', 'woocommerce-custobar' ),
 				'type' => 'password',
 				'desc' => __( 'Enter your Custobar API token.', 'woocommerce-custobar' ),
 				'id'   => 'custobar_api_setting_token',
 			),
-			'custobar_api_company'  => array(
+			'custobar_api_company'           => array(
 				'name' => __( 'Company Domain', 'woocommerce-custobar' ),
 				'type' => 'text',
 				'desc' => __( 'Enter the unique domain prefix for your Custobar account, for example if your Custobar account is at acme123.custobar.com then enter only acme123.', 'woocommerce-custobar' ),
 				'id'   => 'custobar_api_setting_company',
 			),
-			'section_end'           => array(
+			'custobar_rest_api_secret'       => array(
+				'name'              => __( 'Webhook Secret Key', 'woocommerce-custobar' ),
+				'type'              => 'text',
+				'desc'              => __( 'Use this value for the Authorization header when configuring webhooks in Custobar.', 'woocommerce-custobar' ),
+				'id'                => 'custobar_wc_rest_api_secret',
+				'custom_attributes' => array(
+					'readonly' => 'readonly',
+				),
+			),
+			'custobar_rest_api_secret_reset' => array(
+				'name' => __( 'Reset Secret Key', 'woocommerce-custobar' ),
+				'type' => 'checkbox',
+				'desc' => __( 'Check this box to reset webhook secret key.', 'woocommerce-custobar' ),
+				'id'   => 'custobar_wc_rest_api_secret_reset',
+			),
+
+			'section_end'                    => array(
 				'type' => 'sectionend',
 				'id'   => 'custobar_section_end',
 			),
@@ -208,14 +235,14 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 				'sale_stat'     => $sale_stat,
 				'customer_stat' => $customer_stat,
 			);
-			print $template->get();
+			print $template->get();  // @codingStandardsIgnoreLine
 
 		} elseif ( 'api' === $current_section ) {
 
 			$template       = new Template();
 			$template->name = 'api-test';
 			$template->data = array();
-			print $template->get();
+			print $template->get();  // @codingStandardsIgnoreLine
 
 			WC_Admin_Settings::output_fields( $this->get_settings_api() );
 
@@ -268,4 +295,19 @@ class WC_Settings_Custobar extends WC_Settings_Page {
 
 	}
 
+	/**
+	 * Generates a Random String used as a secret key for inbound REST Api requests
+	 *
+	 * @return string
+	 */
+	protected function generate_secret_key() {
+		$length            = 32;
+		$characters        = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+		$characters_length = strlen( $characters );
+		$random_string     = '';
+		for ( $i = 0; $i < $length; $i++ ) {
+			$random_string .= $characters[ wp_rand( 0, $characters_length - 1 ) ];
+		}
+		return $random_string;
+	}
 }

--- a/classes/data-sources/class-customer.php
+++ b/classes/data-sources/class-customer.php
@@ -79,7 +79,7 @@ class Customer extends Abstract_Data_Source {
 	}
 
 	public function get_can_email() {
-		$can_email = get_post_meta( $this->customer->get_id(), '_woocommerce_custobar_can_email', true );
+		$can_email = get_user_meta( $this->customer->get_id(), '_woocommerce_custobar_can_email', true );
 		if ( $can_email ) {
 			return true;
 		}
@@ -90,7 +90,7 @@ class Customer extends Abstract_Data_Source {
 	}
 
 	public function get_can_sms() {
-		$can_sms = get_post_meta( $this->customer->get_id(), '_woocommerce_custobar_can_sms', true );
+		$can_sms = get_user_meta( $this->customer->get_id(), '_woocommerce_custobar_can_sms', true );
 		if ( $can_sms ) {
 			return true;
 		}

--- a/classes/data-sources/class-customer.php
+++ b/classes/data-sources/class-customer.php
@@ -83,10 +83,7 @@ class Customer extends Abstract_Data_Source {
 		if ( $can_email ) {
 			return true;
 		}
-
-		// Never return false as it would override the current value in
-		// Custobar. We don't offer functionality to remove the permission.
-		return null;
+		return false;
 	}
 
 	public function get_can_sms() {
@@ -94,10 +91,7 @@ class Customer extends Abstract_Data_Source {
 		if ( $can_sms ) {
 			return true;
 		}
-
-		// Never return false as it would override the current value in
-		// Custobar. We don't offer functionality to remove the permission.
-		return null;
+		return false;
 	}
 
 	public function get_street_address() {

--- a/classes/data-sources/class-sale.php
+++ b/classes/data-sources/class-sale.php
@@ -48,7 +48,7 @@ class Sale extends Abstract_Data_Source {
 	}
 
 	public function get_total() {
-		$line_total_with_tax = $this->order->get_line_total($this->order_item, true);
+		$line_total_with_tax = $this->order->get_line_total( $this->order_item, true );
 		return Utilities::get_price_in_cents( $line_total_with_tax );
 	}
 

--- a/classes/data-sources/class-sale.php
+++ b/classes/data-sources/class-sale.php
@@ -48,7 +48,8 @@ class Sale extends Abstract_Data_Source {
 	}
 
 	public function get_total() {
-		return Utilities::get_price_in_cents( $this->order_item->get_total() );
+		$line_total_with_tax = $this->order->get_line_total($this->order_item, true);
+		return Utilities::get_price_in_cents( $line_total_with_tax );
 	}
 
 	public function get_order_total() {
@@ -82,7 +83,8 @@ class Sale extends Abstract_Data_Source {
 	}
 
 	public function get_price() {
-		return Utilities::get_price_in_cents( $this->order_item->get_total() / $this->order_item->get_quantity() );
+		$line_total_with_tax = $this->order->get_line_total( $this->order_item, true );
+		return Utilities::get_price_in_cents( $line_total_with_tax / $this->order_item->get_quantity() );
 	}
 
 	public function get_total_discount() {

--- a/classes/data-types/class-utilities.php
+++ b/classes/data-types/class-utilities.php
@@ -37,4 +37,47 @@ class Utilities {
 		// ISO8601 formatted datetime
 		return $datetime->setTimezone( new \DateTimeZone( 'UTC' ) )->format( 'c' );
 	}
+
+	/**
+	 * Get single data item from Custobar
+	 *
+	 * @param string $data_type
+	 * @param int    $external_id
+	 * @return array|boolean|WP_Error If successfull return Custobar data as array, false if no results or WP_Error on failure
+	 */
+	public static function get_data( $data_type, $external_id ) {
+		$api_token      = \WC_Admin_Settings::get_option( 'custobar_api_setting_token', false );
+		$company_domain = \WC_Admin_Settings::get_option( 'custobar_api_setting_company', false );
+		$url            = sprintf( 'https://%s.custobar.com/api', $company_domain ) . '/data/' . $data_type . '/?external_id=' . $external_id;
+
+		$response = wp_remote_request(
+			$url,
+			array(
+				'method'  => 'GET',
+				'headers' => array(
+					'Content-Type'  => 'application/json',
+					'Authorization' => 'Token ' . $api_token,
+				),
+			)
+		);
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		$response_body = wp_remote_retrieve_body( $response );
+
+		if ( 200 === $response_code ) {
+			//Handle successfull request
+			$response_body_array = json_decode( $response_body, true );
+			// Since we are using the external key, we are expecting one result from the correct data type. Just making sure.
+			if ( isset( $response_body_array[ $data_type ] ) && 1 === count( $response_body_array[ $data_type ] ) ) {
+				return $response_body_array[ $data_type ][0];
+			} else {
+				return false;
+			}
+		} else {
+			// Return WP_Error on error
+			$error_response = json_decode( $response_body, true );
+			$error_reason   = $error_response['error']['reason'] ?? '';
+			return new \WP_Error( $response_code, $error_reason );
+		}
+	}
 }

--- a/classes/rest-api/class-rest-marketing-permissions.php
+++ b/classes/rest-api/class-rest-marketing-permissions.php
@@ -1,0 +1,77 @@
+<?php
+namespace WooCommerceCustobar\RestAPI;
+
+use WP_REST_Server;
+
+class REST_Marketing_Permissions extends \WP_REST_Controller {
+	/**
+	 * Hook into WordPress ready to init the REST API as needed.
+	 */
+	public function init() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ), 10 );
+	}
+
+	/**
+	 * Register route for marketing permissions
+	 */
+	public function register_routes() {
+		$version   = '1';
+		$namespace = 'woocommerce-custobar/v' . $version;
+		$base      = 'marketing-permissions';
+		register_rest_route(
+			$namespace,
+			'/' . $base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_marketing_permissions' ),
+					'permission_callback' => array( $this, 'update_marketing_permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Update marketing permissions
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function update_marketing_permissions( $request ) {
+		$request_body = json_decode( $request->get_body(), true );
+
+		if ( isset( $request_body['items'] ) && count( $request_body['items'] ) ) {
+			foreach ( $request_body['items'] as $customer ) {
+				// Check that customer exists
+				if ( isset( $customer['external_id'] ) && (bool) get_user_by( 'id', $customer['external_id'] ) ) {
+					// Update sms permissions if needed
+					if ( isset( $customer['can_sms'] ) ) {
+						update_user_meta( $customer['external_id'], '_woocommerce_custobar_can_sms', (bool) $customer['can_sms'] );
+					}
+					// Update email permissions if needed
+					if ( isset( $customer['can_email'] ) ) {
+						update_user_meta( $customer['external_id'], '_woocommerce_custobar_can_email', (bool) $customer['can_email'] );
+					}
+				}
+			}
+		}
+		return new \WP_REST_Response( '', 200 );
+	}
+
+	/**
+	 * Check that Authorization header matches secret key saved as option
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return bool
+	 */
+	public function update_marketing_permissions_check( $request ) {
+		$secret_key = $request->get_header( 'Authorization' );
+		if ( $secret_key && get_option( 'custobar_wc_rest_api_secret' ) === $secret_key ) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+}
+

--- a/classes/sync-classes/abstract-data-sync.php
+++ b/classes/sync-classes/abstract-data-sync.php
@@ -5,6 +5,7 @@ namespace WooCommerceCustobar\Synchronization;
 defined( 'ABSPATH' ) || exit;
 
 use WooCommerceCustobar\Data_Upload;
+use WooCommerceCustobar\DataSource\Custobar_Data_Source;
 
 /**
  * Class Data_Sync
@@ -13,7 +14,7 @@ use WooCommerceCustobar\Data_Upload;
  */
 abstract class Data_Sync {
 
-
+	abstract public static function schedule_single_update( $item_id );
 	abstract public static function single_update( $item_id );
 	abstract public static function batch_update();
 	abstract protected static function format_single_item( $item );
@@ -26,7 +27,7 @@ abstract class Data_Sync {
 	 *
 	 * @return void
 	 */
-	public static function call_single_update( $id ) {
+	public static function throttle_single_update( $id ) {
 		// Timing
 		$start_time = hrtime( true );
 
@@ -34,32 +35,68 @@ abstract class Data_Sync {
 		$child = static::$child;
 
 		// Do the update
-		$child::single_update( $id );
+		$response = $child::single_update( $id );
+
+		if ( false === $response ) {
+			// Return silently, the data was not meant to be uploaded in the first place
+			return null;
+		}
+
+		if ( is_wp_error( $response ) ) {
+			// Request was invalid, and has been logged already
+			return null;
+		}
+
+		if ( ! in_array( $response->code, array( 200, 201, 429 ) ) ) {
+			// Unexpected response code, fail the action.
+			wc_get_logger()->warning(
+				"#{$id} $child upload, unexpected response code {$response->code}, FAILING",
+				array( 'source' => 'custobar' )
+			);
+
+			// Throw an exception to tell action scheduler to mark action as failed.
+			throw new \Exception( "Custobar upload failed: Unexpected response code '{$response->code}'" );
+		}
 
 		// The request rate limit and concurrent batches
 		$requests_per_minute = apply_filters( 'woocommerce_custobar_requests_per_minute', 180 );
-		$concurrent_batches = apply_filters( 'action_scheduler_queue_runner_concurrent_batches', 1 );
+		$concurrent_batches  = apply_filters( 'action_scheduler_queue_runner_concurrent_batches', 1 );
+
+		// Increase batch number by one for good measure:
+		// If someone launches a queue from admin, the process can get too fast,
+		// and the concurrent_batches-filter does not know about it.
+		$concurrent_batches++;
 
 		// hrtime returns nanoseconds. That's pretty hardcore. Since we're a relaxed bunch, let's convert to microseconds instead.
-		$time_elapsed_in_microseconds = round( ( hrtime( true ) - $start_time ) / 1000 );
+		$time_elapsed_in_microseconds  = round( ( hrtime( true ) - $start_time ) / 1000 );
 		$time_to_sleep_in_microseconds = ( 60 / $requests_per_minute * $concurrent_batches * 1000000 ) - $time_elapsed_in_microseconds;
 		if ( $time_to_sleep_in_microseconds > 0 ) {
 			// Go to sleep
 			usleep( $time_to_sleep_in_microseconds );
 		}
 
+		if ( 429 == $response->code ) {
+			// Too many requests, schedule again
+			wc_get_logger()->warning(
+				"#{$id} $child upload, response code 429 (TOO MANY REQUESTS), RESCHEDULING",
+				array( 'source' => 'custobar' )
+			);
+			$child::schedule_single_update( $id );
+
+			return null;
+		}
+
 		wc_get_logger()->info(
-			"$child updating... concurrent batches: $concurrent_batches, TIME TO SLEEP: " . $time_to_sleep_in_microseconds/1000000 . 's',
+			"#{$id} $child succesful upload, concurrent batches: $concurrent_batches, time to sleep: " . $time_to_sleep_in_microseconds / 1000000 . 's',
 			array( 'source' => 'custobar' )
 		);
 	}
 
 	protected static function upload_custobar_data( $data ) {
-
-		$endpoint = static::$endpoint;
-
-		$cds            = new \WooCommerceCustobar\DataSource\Custobar_Data_Source();
+		$endpoint       = static::$endpoint;
+		$cds            = new Custobar_Data_Source();
 		$integration_id = $cds->get_integration_id();
+
 		if ( ! $integration_id ) {
 			$integration_id = $cds->create_integration();
 		}
@@ -93,6 +130,5 @@ abstract class Data_Sync {
 		}
 
 		return Data_Upload::upload_custobar_data( $endpoint, $data );
-
 	}
 }

--- a/classes/sync-classes/abstract-data-sync.php
+++ b/classes/sync-classes/abstract-data-sync.php
@@ -14,7 +14,7 @@ use WooCommerceCustobar\DataSource\Custobar_Data_Source;
  */
 abstract class Data_Sync {
 
-	abstract public static function schedule_single_update( $item_id );
+	abstract public static function schedule_single_update( $item_id, $force );
 	abstract public static function single_update( $item_id );
 	abstract public static function batch_update();
 	abstract protected static function format_single_item( $item );
@@ -81,7 +81,9 @@ abstract class Data_Sync {
 				"#{$id} $child upload, response code 429 (TOO MANY REQUESTS), RESCHEDULING",
 				array( 'source' => 'custobar' )
 			);
-			$child::schedule_single_update( $id );
+
+			// Force the schedule, since this action still exists
+			$child::schedule_single_update( $id, true );
 
 			return null;
 		}

--- a/classes/sync-classes/abstract-data-sync.php
+++ b/classes/sync-classes/abstract-data-sync.php
@@ -14,10 +14,45 @@ use WooCommerceCustobar\Data_Upload;
 abstract class Data_Sync {
 
 
-	abstract public static function single_update( $item_id);
+	abstract public static function single_update( $item_id );
 	abstract public static function batch_update();
-	abstract protected static function format_single_item( $item);
-	abstract protected static function upload_data_type_data( $data);
+	abstract protected static function format_single_item( $item );
+	abstract protected static function upload_data_type_data( $data );
+
+	/**
+	 * Handle single update timing
+	 * consider Custobar's default request limit of 180 per minute,
+	 * and go to sleep if processing too fast.
+	 *
+	 * @return void
+	 */
+	public static function call_single_update( $id ) {
+		// Timing
+		$start_time = hrtime( true );
+
+		// The child class that called this method
+		$child = static::$child;
+
+		// Do the update
+		$child::single_update( $id );
+
+		// The request rate limit and concurrent batches
+		$requests_per_minute = apply_filters( 'woocommerce_custobar_requests_per_minute', 180 );
+		$concurrent_batches = apply_filters( 'action_scheduler_queue_runner_concurrent_batches', 1 );
+
+		// hrtime returns nanoseconds. That's pretty hardcore. Since we're a relaxed bunch, let's convert to microseconds instead.
+		$time_elapsed_in_microseconds = round( ( hrtime( true ) - $start_time ) / 1000 );
+		$time_to_sleep_in_microseconds = ( 60 / $requests_per_minute * $concurrent_batches * 1000000 ) - $time_elapsed_in_microseconds;
+		if ( $time_to_sleep_in_microseconds > 0 ) {
+			// Go to sleep
+			usleep( $time_to_sleep_in_microseconds );
+		}
+
+		wc_get_logger()->info(
+			"$child updating... concurrent batches: $concurrent_batches, TIME TO SLEEP: " . $time_to_sleep_in_microseconds/1000000 . 's',
+			array( 'source' => 'custobar' )
+		);
+	}
 
 	protected static function upload_custobar_data( $data ) {
 

--- a/classes/sync-classes/class-customer-sync.php
+++ b/classes/sync-classes/class-customer-sync.php
@@ -81,26 +81,7 @@ class Customer_Sync extends Data_Sync {
 			$properties     = self::format_single_item( $customer );
 			$initial_export = false;
 
-			// Have initial marketing permissions been exported?
-			if ( ! get_user_meta( $user_id, '_custobar_permissions_export', true ) ) {
-				// Push initial marketing permissions with customer object
-				$initial_export = true;
-
-				if ( 'yes' === get_option( 'custobar_initial_can_email' ) ) {
-					$properties['can_email'] = true;
-				}
-
-				if ( 'yes' === get_option( 'custobar_initial_can_sms' ) ) {
-					$properties['can_sms'] = true;
-				}
-			}
-
 			$response = self::upload_data_type_data( $properties, true );
-
-			if ( ! is_wp_error( $response ) && in_array( $response->code, array( 200, 201 ) ) && $initial_export ) {
-				// Initial export done
-				update_user_meta( $user_id, '_custobar_permissions_export', gmdate( 'c' ) );
-			}
 
 			return $response;
 

--- a/classes/sync-classes/class-customer-sync.php
+++ b/classes/sync-classes/class-customer-sync.php
@@ -29,7 +29,7 @@ class Customer_Sync extends Data_Sync {
 		add_action( 'woocommerce_custobar_customer_sync', array( __CLASS__, 'throttle_single_update' ), 10, 1 );
 	}
 
-	public static function schedule_single_update( $user_id ) {
+	public static function schedule_single_update( $user_id, $force = false ) {
 		// Allow 3rd parties to decide if customer should be synced
 		if ( ! apply_filters( 'woocommerce_custobar_customer_should_sync', true, $user_id ) ) {
 			return;
@@ -38,6 +38,17 @@ class Customer_Sync extends Data_Sync {
 		$hook  = 'woocommerce_custobar_customer_sync';
 		$args  = array( 'user_id' => $user_id );
 		$group = 'custobar';
+
+		// Force schedule
+		// For example reschedule when action still in progress
+		if ( $force ) {
+			as_schedule_single_action( time(), $hook, $args, $group );
+
+			wc_get_logger()->info(
+				'#' . $user_id . ' NEW/UPDATE CUSTOMER, SYNC SCHEDULED (FORCE)',
+				array( 'source' => 'custobar' )
+			);
+		}
 
 		// We need only one action scheduled
 		if ( ! as_next_scheduled_action( $hook, $args, $group ) ) {

--- a/classes/sync-classes/class-product-sync.php
+++ b/classes/sync-classes/class-product-sync.php
@@ -27,7 +27,7 @@ class Product_Sync extends Data_Sync {
 		add_action( 'woocommerce_custobar_product_sync', array( __CLASS__, 'throttle_single_update' ), 10, 1 );
 	}
 
-	public static function schedule_single_update( $product_id ) {
+	public static function schedule_single_update( $product_id, $force = false ) {
 		// Allow 3rd parties to decide if product should be synced
 		if ( ! apply_filters( 'woocommerce_custobar_product_should_sync', true, $product_id ) ) {
 			return;
@@ -36,6 +36,17 @@ class Product_Sync extends Data_Sync {
 		$hook  = 'woocommerce_custobar_product_sync';
 		$args  = array( 'product_id' => $product_id );
 		$group = 'custobar';
+
+		// Force schedule
+		// For example reschedule when action still in progress
+		if ( $force ) {
+			as_schedule_single_action( time(), $hook, $args, $group );
+
+			wc_get_logger()->info(
+				'#' . $product_id . ' NEW/UPDATE PRODUCT, SYNC SCHEDULED (FORCE)',
+				array( 'source' => 'custobar' )
+			);
+		}
 
 		// We need only one action scheduled
 		if ( ! as_next_scheduled_action( $hook, $args, $group ) ) {

--- a/classes/sync-classes/class-product-sync.php
+++ b/classes/sync-classes/class-product-sync.php
@@ -15,6 +15,7 @@ class Product_Sync extends Data_Sync {
 
 
 	protected static $endpoint = '/products/upload/';
+	protected static $child = __CLASS__;
 
 	public static function add_hooks() {
 		// Schedule actions
@@ -22,14 +23,15 @@ class Product_Sync extends Data_Sync {
 		add_action( 'woocommerce_update_product', array( __CLASS__, 'schedule_single_update' ), 10, 1 );
 
 		// Hook into scheduled actions
-		add_action( 'woocommerce_custobar_product_sync', array( __CLASS__, 'single_update' ), 10, 1 );
+		// Call parent method to consider request limit
+		add_action( 'woocommerce_custobar_product_sync', array( __CLASS__, 'call_single_update' ), 10, 1 );
 	}
 
 	public static function schedule_single_update( $product_id ) {
-		wc_get_logger()->info(
-			'Product_Sync schedule_single_update called with $product_id: ' . $product_id,
-			array( 'source' => 'custobar' )
-		);
+		// Allow 3rd parties to decide if product should be synced
+		if ( ! apply_filters( 'woocommerce_custobar_product_should_sync', true, $product_id ) ) {
+			return;
+		}
 
 		$hook  = 'woocommerce_custobar_product_sync';
 		$args  = array( 'product_id' => $product_id );
@@ -37,13 +39,23 @@ class Product_Sync extends Data_Sync {
 
 		// We need only one action scheduled
 		if ( ! as_next_scheduled_action( $hook, $args, $group ) ) {
-			as_enqueue_async_action( $hook, $args, $group );
+			as_schedule_single_action( time(), $hook, $args, $group );
+
+			wc_get_logger()->info(
+				'#' . $product_id . ' NEW/UPDATE PRODUCT, SYNC SCHEDULED',
+				array( 'source' => 'custobar' )
+			);
+		} else {
+			wc_get_logger()->info(
+				'#' . $product_id . ' NEW/UPDATE PRODUCT, sync was already scheduled',
+				array( 'source' => 'custobar' )
+			);
 		}
 	}
 
 	public static function single_update( $product_id ) {
 		wc_get_logger()->info(
-			'Product_Sync single update called with $product_id: ' . $product_id,
+			'#' . $product_id . ' PRODUCT SYNC, UPLOADING TO CUSTOBAR',
 			array( 'source' => 'custobar' )
 		);
 

--- a/classes/sync-classes/class-sale-sync.php
+++ b/classes/sync-classes/class-sale-sync.php
@@ -38,7 +38,7 @@ class Sale_Sync extends Data_Sync {
 	 * @param int/string $order_id
 	 * @return void
 	 */
-	public static function schedule_single_update( $order_id ) {
+	public static function schedule_single_update( $order_id, $force = false ) {
 		if ( ! $order_id ) {
 			return;
 		}
@@ -56,6 +56,17 @@ class Sale_Sync extends Data_Sync {
 		$hook  = 'woocommerce_custobar_sale_sync';
 		$args  = array( 'order_id' => $order_id );
 		$group = 'custobar';
+
+		// Force schedule
+		// For example reschedule when action still in progress
+		if ( $force ) {
+			as_schedule_single_action( time(), $hook, $args, $group );
+
+			wc_get_logger()->info(
+				'#' . $order_id . ' NEW/UPDATE ORDER, SYNC SCHEDULED (FORCE)',
+				array( 'source' => 'custobar' )
+			);
+		}
 
 		// We need only one action scheduled
 		if ( ! as_next_scheduled_action( $hook, $args, $group ) ) {

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -16,7 +16,7 @@ function woocommerce_checkout_fields( $checkout_fields = array() ) {
 		$checkout_fields['order']['custobar_can_email'] = array(
 			'type'     => 'checkbox',
 			'class'    => array( 'my-field-class form-row-wide' ),
-			'label'    => __( 'Allow email marketing', 'woocommerce-custobar' ),
+			'label'    => __( 'I would like to receive marketing messages via email', 'woocommerce-custobar' ),
 			'required' => false,
 			'default'  => true,
 		);
@@ -25,7 +25,7 @@ function woocommerce_checkout_fields( $checkout_fields = array() ) {
 		$checkout_fields['order']['custobar_can_sms'] = array(
 			'type'     => 'checkbox',
 			'class'    => array( 'my-field-class form-row-wide' ),
-			'label'    => __( 'Allow SMS marketing', 'woocommerce-custobar' ),
+			'label'    => __( 'I would like to receive marketing messages via SMS', 'woocommerce-custobar' ),
 			'required' => false,
 			'default'  => true,
 		);

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -48,7 +48,7 @@ function woocommerce_checkout_update_user_meta( $customer_id, $posted ) {
 		update_user_meta( $customer_id, '_woocommerce_custobar_can_email', $can_email );
 	}
 	if ( apply_filters( 'woocommerce_custobar_show_sms_permission_setting_checkout', true ) ) {
-		$can_sms = ( isset( $posted['custobar_can_email'] ) && $posted['custobar_can_sms'] ) ? true : false;
+		$can_sms = ( isset( $posted['custobar_can_sms'] ) && $posted['custobar_can_sms'] ) ? true : false;
 		update_user_meta( $customer_id, '_woocommerce_custobar_can_sms', $can_sms );
 	}
 

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace WooCommerceCustobar;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Add Custobar marketing permissions to checkout fields
+ *
+ * @param array $checkout_fields
+ * @return void
+ */
+function woocommerce_checkout_fields( $checkout_fields = array() ) {
+
+	if ( apply_filters( 'woocommerce_custobar_show_email_permission_setting_checkout', true ) ) {
+		$checkout_fields['order']['custobar_can_email'] = array(
+			'type'     => 'checkbox',
+			'class'    => array( 'my-field-class form-row-wide' ),
+			'label'    => __( 'Allow email marketing', 'woocommerce-custobar' ),
+			'required' => false,
+			'default'  => true,
+		);
+	}
+	if ( apply_filters( 'woocommerce_custobar_show_sms_permission_setting_checkout', true ) ) {
+		$checkout_fields['order']['custobar_can_sms'] = array(
+			'type'     => 'checkbox',
+			'class'    => array( 'my-field-class form-row-wide' ),
+			'label'    => __( 'Allow SMS marketing', 'woocommerce-custobar' ),
+			'required' => false,
+			'default'  => true,
+		);
+	}
+
+	return $checkout_fields;
+}
+add_filter( 'woocommerce_checkout_fields', __NAMESPACE__ . '\\woocommerce_checkout_fields' );
+
+/**
+ * Save Custobar marketing permissions as user data
+ *
+ * @param integer $customer_id
+ * @param array   $posted
+ * @return void
+ */
+function woocommerce_checkout_update_user_meta( $customer_id, $posted ) {
+	if ( apply_filters( 'woocommerce_custobar_show_email_permission_setting_checkout', true ) ) {
+		$can_email = ( isset( $posted['custobar_can_email'] ) && $posted['custobar_can_email'] ) ? true : false;
+		update_user_meta( $customer_id, '_woocommerce_custobar_can_email', $can_email );
+	}
+	if ( apply_filters( 'woocommerce_custobar_show_sms_permission_setting_checkout', true ) ) {
+		$can_sms = ( isset( $posted['custobar_can_email'] ) && $posted['custobar_can_sms'] ) ? true : false;
+		update_user_meta( $customer_id, '_woocommerce_custobar_can_sms', $can_sms );
+	}
+
+}
+add_action( 'woocommerce_checkout_update_user_meta', __NAMESPACE__ . '\\woocommerce_checkout_update_user_meta', 10, 2 );

--- a/includes/my-account.php
+++ b/includes/my-account.php
@@ -1,0 +1,53 @@
+<?php
+namespace WooCommerceCustobar;
+
+/**
+ * Add marketing permissions to Account Details tab in My Account page
+ *
+ * Please note that the values are fetched from Custobar on each page load unless we have
+ * a pending update from WooCommerce to Custobar already scheduled.
+ *
+ * In the future a webhook based approach would be more sustainable.
+ *
+ * @return void
+ */
+function woocommerce_edit_account_form_marketing_permissions() {
+	$allow_email_marketing_checked = get_user_meta( get_current_user_id(), '_woocommerce_custobar_can_email', true ) ? true : '';
+	$allow_sms_marketing_checked   = get_user_meta( get_current_user_id(), '_woocommerce_custobar_can_sms', true ) ? true : '';
+	if ( apply_filters( 'woocommerce_custobar_show_email_permission_setting_my_account', true ) ) : ?>
+	<p class="form-row form-row-wide">
+		<span class="woocommerce-input-wrapper">
+			<label for="custobar_can_email" class="checkbox">
+				<input type="checkbox" class="input-checkbox" name="custobar_can_email" id="custobar_can_email" <?php checked( $allow_email_marketing_checked, true, true ); ?>>
+				<?php esc_html_e( 'Allow email marketing', 'woocommerce-custobar' ); ?>
+			</label>
+		</span> 
+	</p>
+	<?php endif; ?>
+	<?php if ( apply_filters( 'woocommerce_custobar_show_sms_permission_setting_my_account', true ) ) : ?>
+	<p class="form-row form-row-wide">
+		<span class="woocommerce-input-wrapper">
+			<label for="custobar_can_sms" class="checkbox">
+				<input type="checkbox" class="input-checkbox" name="custobar_can_sms" id="custobar_can_sms" <?php checked( $allow_sms_marketing_checked, true, true ); ?>>
+				<?php esc_html_e( 'Allow SMS marketing', 'woocommerce-custobar' ); ?>
+			</label>
+		</span> 
+	</p>
+		<?php
+	endif;
+}
+add_action( 'woocommerce_edit_account_form', __NAMESPACE__ . '\\woocommerce_edit_account_form_marketing_permissions' );
+
+// Save marketing permission fields as user meta
+function woocommerce_save_account_details( $customer_id ) {
+	if ( apply_filters( 'woocommerce_custobar_show_email_permission_setting_my_account', true ) ) {
+		$can_email = ( isset( $_POST['custobar_can_email'] ) && $_POST['custobar_can_email'] ) ? true : false; // @codingStandardsIgnoreLine
+		update_user_meta( $customer_id, '_woocommerce_custobar_can_email', $can_email );
+	}
+	if ( apply_filters( 'woocommerce_custobar_show_sms_permission_setting_my_account', true ) ) {
+		$can_sms = ( isset( $_POST['custobar_can_sms'] ) && $_POST['custobar_can_sms'] ) ? true : false; // @codingStandardsIgnoreLine
+		update_user_meta( $customer_id, '_woocommerce_custobar_can_sms', $can_sms );
+	}
+}
+add_action( 'woocommerce_save_account_details', __NAMESPACE__ . '\\woocommerce_save_account_details', 10, 1 );
+

--- a/includes/my-account.php
+++ b/includes/my-account.php
@@ -19,7 +19,7 @@ function woocommerce_edit_account_form_marketing_permissions() {
 		<span class="woocommerce-input-wrapper">
 			<label for="custobar_can_email" class="checkbox">
 				<input type="checkbox" class="input-checkbox" name="custobar_can_email" id="custobar_can_email" <?php checked( $allow_email_marketing_checked, true, true ); ?>>
-				<?php esc_html_e( 'Allow email marketing', 'woocommerce-custobar' ); ?>
+				<?php esc_html_e( 'I would like to receive marketing messages via Email', 'woocommerce-custobar' ); ?>
 			</label>
 		</span> 
 	</p>
@@ -29,7 +29,7 @@ function woocommerce_edit_account_form_marketing_permissions() {
 		<span class="woocommerce-input-wrapper">
 			<label for="custobar_can_sms" class="checkbox">
 				<input type="checkbox" class="input-checkbox" name="custobar_can_sms" id="custobar_can_sms" <?php checked( $allow_sms_marketing_checked, true, true ); ?>>
-				<?php esc_html_e( 'Allow SMS marketing', 'woocommerce-custobar' ); ?>
+				<?php esc_html_e( 'I would like to receive marketing messages via SMS', 'woocommerce-custobar' ); ?>
 			</label>
 		</span> 
 	</p>

--- a/templates/api-test.php
+++ b/templates/api-test.php
@@ -1,6 +1,6 @@
 <div id="custobar-api-connection-test-wrap">
   <h2>Test Custobar API Connection</h2>
   <p>Test uses the credentials you have already saved, if you are making changes press the save changes button before running this test.</p>
-  <button id="custobar-api-connection-test">Test API Connection</button>
+  <button id="custobar-api-connection-test" class="button button-alt">Test API Connection</button>
   <hr />
 </div>

--- a/templates/sync-report.php
+++ b/templates/sync-report.php
@@ -1,6 +1,6 @@
 <div id="custobar-export-wrap">
 	<h2>Custobar Sync Status</h2>
-	<table>
+	<table class="custobar-sync-report">
 	<thead>
 	<tr>
 		<th>Record Type</th>
@@ -9,6 +9,7 @@
 		<th class="custobar-center">Sync %</th>
 		<th>Last Export</th>
 		<th>Reset</th>
+		<th colspan="2">Set marketing permissions</th>
 		<th>&nbsp;</th>
 	</tr>
 	</thead>
@@ -20,7 +21,9 @@
 			<td class="custobar-center"><?php echo esc_html($product_stat->synced_percent); ?></td>
 			<td><?php echo esc_html($product_stat->last_updated); ?></td>
 			<td><input name="reset-product" type="checkbox" value="1"></td>
-			<td><button class="custobar-export" data-record-type="product">Run Exporter</button></td>
+			<td></td>
+			<td></td>
+			<td><button class="custobar-export button button-alt" data-record-type="product">Run Exporter</button></td>
 		</tr>
 		<tr class="sync-report-customer">
 			<td>Customers</td>
@@ -29,7 +32,9 @@
 			<td class="custobar-center"><?php echo esc_html($customer_stat->synced_percent); ?></td>
 			<td><?php echo esc_html($customer_stat->last_updated); ?></td>
 			<td><input name="reset-customer" type="checkbox" value="1"></td>
-			<td><button class="custobar-export" data-record-type="customer">Run Exporter</button></td>
+			<td><input name="can-email-customer" type="checkbox" value="1">can_email</td>
+			<td><input name="can-sms-customer" type="checkbox" value="1">can_sms</td>
+			<td><button class="custobar-export button button-alt" data-record-type="customer">Run Exporter</button></td>
 		</tr>
 		<tr class="sync-report-sale">
 			<td>Sales</td>
@@ -38,7 +43,9 @@
 			<td class="custobar-center"><?php echo esc_html($sale_stat->synced_percent); ?></td>
 			<td><?php echo esc_html($sale_stat->last_updated); ?></td>
 			<td><input name="reset-sale" type="checkbox" value="1"></td>
-			<td><button class="custobar-export" data-record-type="sale">Run Exporter</button></td>
+			<td></td>
+			<td></td>
+			<td><button class="custobar-export button button-alt" data-record-type="sale">Run Exporter</button></td>
 		</tr>
 	<tbody>
 	</table>

--- a/woocommerce-custobar.php
+++ b/woocommerce-custobar.php
@@ -5,7 +5,7 @@
  * Description: Syncs your WooCommerce data with Custobar.
  * Author: Custobar
  * Text Domain: woocommerce-custobar
- * Version: 2.2.0
+ * Version: 2.3.0
  * Domain Path: /languages
  * WC requires at least: 4.0
  * Requires PHP 7.2+

--- a/woocommerce-custobar.php
+++ b/woocommerce-custobar.php
@@ -48,6 +48,7 @@ require_once WOOCOMMERCE_CUSTOBAR_PATH . '/classes/data-sources/class-product.ph
 require_once WOOCOMMERCE_CUSTOBAR_PATH . '/classes/data-sources/class-customer.php';
 require_once WOOCOMMERCE_CUSTOBAR_PATH . '/classes/data-sources/class-sale.php';
 require_once WOOCOMMERCE_CUSTOBAR_PATH . '/classes/data-sources/class-custobar-data-source.php';
+require_once WOOCOMMERCE_CUSTOBAR_PATH . '/classes/rest-api/class-rest-marketing-permissions.php';
 
 // Add settings page
 add_filter(
@@ -65,6 +66,8 @@ register_deactivation_hook( __FILE__, array( 'WooCommerceCustobar\Plugin', 'deac
 // Initialize plugin after WooCommerce is loaded
 add_action( 'plugins_loaded', array( 'WooCommerceCustobar\Plugin', 'initialize' ) );
 
+// Initialize Rest API endpoint
+add_action( 'init', array( new \WooCommerceCustobar\RestAPI\REST_Marketing_Permissions(), 'init' ) );
+
 // Load translations
 add_action( 'init', 'WooCommerceCustobar\load_textdomain' );
-

--- a/woocommerce-custobar.php
+++ b/woocommerce-custobar.php
@@ -5,7 +5,7 @@
  * Description: Syncs your WooCommerce data with Custobar.
  * Author: Custobar
  * Text Domain: woocommerce-custobar
- * Version: 2.0.0
+ * Version: 2.1.0
  * Domain Path: /languages
  * WC requires at least: 4.0
  * Requires PHP 7.2+
@@ -22,7 +22,7 @@ if ( ! defined( 'WOOCOMMERCE_CUSTOBAR_URL' ) ) {
 }
 
 if ( ! defined( 'WOOCOMMERCE_CUSTOBAR_VERSION' ) ) {
-	define( 'WOOCOMMERCE_CUSTOBAR_VERSION', '2.0.0' );
+	define( 'WOOCOMMERCE_CUSTOBAR_VERSION', '2.1.0' );
 }
 
 require_once WOOCOMMERCE_CUSTOBAR_PATH . '/includes/functions.php';

--- a/woocommerce-custobar.php
+++ b/woocommerce-custobar.php
@@ -5,7 +5,7 @@
  * Description: Syncs your WooCommerce data with Custobar.
  * Author: Custobar
  * Text Domain: woocommerce-custobar
- * Version: 2.1.0
+ * Version: 2.2.0
  * Domain Path: /languages
  * WC requires at least: 4.0
  * Requires PHP 7.2+
@@ -22,7 +22,7 @@ if ( ! defined( 'WOOCOMMERCE_CUSTOBAR_URL' ) ) {
 }
 
 if ( ! defined( 'WOOCOMMERCE_CUSTOBAR_VERSION' ) ) {
-	define( 'WOOCOMMERCE_CUSTOBAR_VERSION', '2.1.0' );
+	define( 'WOOCOMMERCE_CUSTOBAR_VERSION', '2.2.0' );
 }
 
 require_once WOOCOMMERCE_CUSTOBAR_PATH . '/includes/functions.php';

--- a/woocommerce-custobar.php
+++ b/woocommerce-custobar.php
@@ -26,6 +26,8 @@ if ( ! defined( 'WOOCOMMERCE_CUSTOBAR_VERSION' ) ) {
 }
 
 require_once WOOCOMMERCE_CUSTOBAR_PATH . '/includes/functions.php';
+require_once WOOCOMMERCE_CUSTOBAR_PATH . '/includes/checkout.php';
+require_once WOOCOMMERCE_CUSTOBAR_PATH . '/includes/my-account.php';
 require_once WOOCOMMERCE_CUSTOBAR_PATH . '/classes/class-plugin.php';
 require_once WOOCOMMERCE_CUSTOBAR_PATH . '/classes/class-data-upload.php';
 require_once WOOCOMMERCE_CUSTOBAR_PATH . '/classes/data-types/abstract-custobar-data-type.php';


### PR DESCRIPTION
Adds support for marketing permissions.

## Checkout and My Account

The permissions can be controlled by the customer at:

- Checkout
- My Account -> Account details -page

Please note that the can_email and can_sms fields are sent to Custobar every time the customer is updated. Essentially this means, that if marketing permissions have been controlled at Custobar only, you'd need update the settings for each customer **from** Custobar **to** WooCommerce before updating to version 2.3.0 of the plugin.

## Rest API and webhooks

This Pull Request also includes a custom Rest API endpoint that allows two-way sync from Custobar to WooCommerce using the Webhook feature of Custobar. 

The format of the incoming payload should be the following:

```
{
  "items": [
    {
      "external_id": "2", 
      "can_email": false, 
      "can_sms": false
    }
  ]
}
```

Please note that you'll also need to configure a Request header at Custobar. The name of the header field is _Authorization_ and the value of the field should be copied from the _Webhook Secret Key_ field in the _API settings_ section in WooCommerce admin panel.