### PR TITLE
Version 2.7.0: Sync variations during single product sync

### DIFF
--- a/classes/sync-classes/class-product-sync.php
+++ b/classes/sync-classes/class-product-sync.php
@@ -132,7 +132,7 @@ class Product_Sync extends Data_Sync {
 			$formatted_products[] = self::format_single_item( $product );
 
 			if ( $product instanceof \WC_Product_Variable ) {
-				$variations = $product->get_available_variations();
+				$variations = $product->get_available_variations( 'objects' );
 				foreach ( $variations as $variation ) {
 					$formatted_products[] = self::format_single_variant( $variation );
 				}

--- a/classes/sync-classes/class-product-sync.php
+++ b/classes/sync-classes/class-product-sync.php
@@ -126,11 +126,17 @@ class Product_Sync extends Data_Sync {
 
 		$product = wc_get_product( $product_id );
 
+		$formatted_products = array();
+
 		if ( $product ) {
+			$formatted_products[] = self::format_single_item( $product );
 
-			$properties = self::format_single_item( $product );
-			return self::upload_data_type_data( $properties, true );
-
+			if ( $product instanceof \WC_Product_Variable ) {
+				$variations = $product->get_available_variations();
+				foreach ( $variations as $variation ) {
+					$formatted_products[] = self::format_single_variant( $variation );
+				}
+			}
 		} else {
 
 			wc_get_logger()->warning(
@@ -138,6 +144,10 @@ class Product_Sync extends Data_Sync {
 				array( 'source' => 'custobar' )
 			);
 
+		}
+
+		if ( count( $formatted_products ) ) {
+			return self::upload_data_type_data( $formatted_products );
 		}
 
 		return false;

--- a/woocommerce-custobar.php
+++ b/woocommerce-custobar.php
@@ -5,7 +5,7 @@
  * Description: Syncs your WooCommerce data with Custobar.
  * Author: Custobar
  * Text Domain: woocommerce-custobar
- * Version: 2.6.0
+ * Version: 2.7.0
  * Domain Path: /languages
  * WC requires at least: 5.0
  * Requires PHP 7.4+


### PR DESCRIPTION
Changelog:

- During sync of single product (creating new product or updating existing one) will now check if product is variable and, if necessary, also sync variations. Uses existing variation upload properties (that include main_product_ids field).
- Update plugin version to 2.7.0