### PR TITLE
Bug fixes for invalid total count and custom fields not included for unregisted users in export customers

### DIFF
--- a/classes/data-types/abstract-custobar-data-type.php
+++ b/classes/data-types/abstract-custobar-data-type.php
@@ -37,7 +37,7 @@ abstract class Custobar_Data_Type {
 
 		foreach ( $fields_map as $custobar_key => $source_key ) {
 			// Custom_data_source
-			if ( is_array( $data_source_fields[ $source_key ] ) && 'get_custom_data_source' === $data_source_fields[ $source_key ][0] && $param ) {
+			if (isset( $data_source_fields[ $source_key ] ) && is_array( $data_source_fields[ $source_key ] ) && 'get_custom_data_source' === $data_source_fields[ $source_key ][0] && $param ) {
 
 				$method_or_fn           = $data_source_fields[ $source_key ];
 					$custom_data_source = Abstract_Data_Source::get_custom_data_source( $method_or_fn[1] );

--- a/classes/data-types/abstract-custobar-data-type.php
+++ b/classes/data-types/abstract-custobar-data-type.php
@@ -30,6 +30,9 @@ abstract class Custobar_Data_Type {
 	public function get_assigned_properties( $param = null ) {
 		$data_source_fields = $this->data_source->get_fields();
 		$fields_map         = static::get_fields_map();
+		$meta_data_fields   = $param ? array_map(function ($meta) {
+			return $meta->key;
+		}, $param->get_meta_data()) : [];
 		$properties         = array();
 
 		foreach ( $fields_map as $custobar_key => $source_key ) {
@@ -47,6 +50,11 @@ abstract class Custobar_Data_Type {
 				continue;
 			}
 			// Custom_data_source ends
+
+			if ($param && in_array($source_key, $meta_data_fields)) {
+				$properties[ $custobar_key ] = $param->get_meta($source_key);
+				continue;
+			}
 
 			if ( ! in_array( $custobar_key, static::$default_keys, true ) ) {
 				continue;

--- a/classes/sync-classes/class-customer-sync.php
+++ b/classes/sync-classes/class-customer-sync.php
@@ -106,7 +106,7 @@ class Customer_Sync extends Data_Sync {
 			}
 
 			$processed_count = count( $customers );
-			$total_count     = count( $newest_orders_by_email );
+			$total_count     = $results->total;
 
 			// Upload data
 			$api_response = self::upload_data_type_data( $customers );

--- a/classes/sync-classes/class-customer-sync.php
+++ b/classes/sync-classes/class-customer-sync.php
@@ -232,6 +232,7 @@ class Customer_Sync extends Data_Sync {
 		$billing_postcode   = $order->get_billing_postcode();
 		$billing_state      = $order->get_billing_state();
 		$billing_country    = $order->get_billing_country();
+		$meta_data          = $order->get_meta_data();
 		$billing_address    = self::get_street_address( $order );
 
 		// Check if customer exists
@@ -250,6 +251,10 @@ class Customer_Sync extends Data_Sync {
 		$customer->set_billing_state( $billing_state );
 		$customer->set_billing_country( $billing_country );
 		$customer->set_billing_address( $billing_address );
+
+		foreach ($meta_data as $data) {
+			$customer->update_meta_data($data->key, $data->value);
+		}
 
 		return $customer;
 	}

--- a/classes/sync-classes/class-customer-sync.php
+++ b/classes/sync-classes/class-customer-sync.php
@@ -48,8 +48,8 @@ class Customer_Sync extends Data_Sync {
 				WHERE p.post_type = 'shop_order'
 				AND pm.meta_key = '_billing_email'
 				GROUP BY pm.meta_value
-				ORDER BY p.ID DESC LIMIT {$limit} OFFSET {$offset}
-			")));
+				ORDER BY p.ID DESC LIMIT %d OFFSET %d
+			", [$limit, $offset])));
 
 			// Get orders by offset and limit
 			$args = array(

--- a/classes/sync-classes/class-customer-sync.php
+++ b/classes/sync-classes/class-customer-sync.php
@@ -42,18 +42,18 @@ class Customer_Sync extends Data_Sync {
 			$order_ids = array_map(function ($row) {
 				return $row->id;
 			},
-			$wpdb->get_results("
-				SELECT MAX(p.id) as id FROM {$wpdb->prefix}posts p
-				INNER JOIN {$wpdb->prefix}postmeta pm ON p.ID = pm.post_id
+			$wpdb->get_results($wpdb->prepare("
+				SELECT MAX(p.ID) as id FROM $wpdb->posts p
+				INNER JOIN $wpdb->postmeta pm ON p.ID = pm.post_id
 				WHERE p.post_type = 'shop_order'
 				AND pm.meta_key = '_billing_email'
 				GROUP BY pm.meta_value
 				ORDER BY p.ID DESC LIMIT {$limit} OFFSET {$offset}
-			"));
+			")));
 
 			// Get orders by offset and limit
 			$args = array(
-				'post__in'       => $order_ids,
+				'post__in' => $order_ids,
 				'type'     => 'shop_order', // skip shop_order_refund
 				'orderby'  => 'ID',
 				'order'    => 'DESC',
@@ -117,10 +117,10 @@ class Customer_Sync extends Data_Sync {
 				}
 			}
 
-			$processed_count = count( $customers );
-			$total_count     = (int)$wpdb->get_var("
-				SELECT COUNT(*) FROM (SELECT MAX(p.id) FROM wp_posts p
-				INNER JOIN wp_postmeta pm ON p.ID = pm.post_id
+			$processed_count = count( $orders );
+			$total_count     = (int) $wpdb->get_var("
+				SELECT COUNT(*) FROM (SELECT MAX(p.ID) FROM $wpdb->posts p
+				INNER JOIN $wpdb->postmeta pm ON p.ID = pm.post_id
 				WHERE p.post_type = 'shop_order'
 				AND pm.meta_key = '_billing_email'
 				GROUP BY pm.meta_value) q

--- a/classes/sync-classes/class-customer-sync.php
+++ b/classes/sync-classes/class-customer-sync.php
@@ -53,7 +53,7 @@ class Customer_Sync extends Data_Sync {
 
 			// Get orders by offset and limit
 			$args = array(
-				'id'       => $order_ids,
+				'post__in'       => $order_ids,
 				'type'     => 'shop_order', // skip shop_order_refund
 				'orderby'  => 'ID',
 				'order'    => 'DESC',

--- a/woocommerce-custobar.php
+++ b/woocommerce-custobar.php
@@ -85,18 +85,3 @@ function custobar_tracking_script() {
 }
 
 add_action( 'wp_head', 'custobar_tracking_script' );
-
-function handle_custom_query_var($query, $query_vars) {
-	if (!empty($query_vars['id']) ) {
-		if (is_array($query_vars['id'])) {
-			$query['post__in'] = $query_vars['id'];
-		}
-		else {
-			$query['post'] = esc_attr($query_vars['id']);
-		}
-	}
-
-	return $query;
-}
-
-add_filter('woocommerce_order_data_store_cpt_get_orders_query', 'handle_custom_query_var', 10, 2);

--- a/woocommerce-custobar.php
+++ b/woocommerce-custobar.php
@@ -85,3 +85,18 @@ function custobar_tracking_script() {
 }
 
 add_action( 'wp_head', 'custobar_tracking_script' );
+
+function handle_custom_query_var($query, $query_vars) {
+	if (!empty($query_vars['id']) ) {
+		if (is_array($query_vars['id'])) {
+			$query['post__in'] = $query_vars['id'];
+		}
+		else {
+			$query['post'] = esc_attr($query_vars['id']);
+		}
+	}
+
+	return $query;
+}
+
+add_filter('woocommerce_order_data_store_cpt_get_orders_query', 'handle_custom_query_var', 10, 2);

--- a/woocommerce-custobar.php
+++ b/woocommerce-custobar.php
@@ -5,7 +5,7 @@
  * Description: Syncs your WooCommerce data with Custobar.
  * Author: Custobar
  * Text Domain: woocommerce-custobar
- * Version: 2.7.0
+ * Version: 2.8.0
  * Domain Path: /languages
  * WC requires at least: 5.0
  * Requires PHP 7.4+


### PR DESCRIPTION
Changes:

- Customers are now fetched using a custom query to ensure that only the most recent orders with unique emails will be processed
- Total count is calculated from the custom query so that each order will get handled
- Order meta is now passed to the WC_Customer object so that the custom fields can be mapped from there to the request that sends customer data to Custobar