### PR TITLE
Force sleep time to be an integer instead float

### DIFF
--- a/classes/sync-classes/abstract-data-sync.php
+++ b/classes/sync-classes/abstract-data-sync.php
@@ -102,7 +102,7 @@ abstract class Data_Sync {
 
 		// hrtime returns nanoseconds. That's pretty hardcore. Since we're a relaxed bunch, let's convert to microseconds instead.
 		$time_elapsed_in_microseconds  = round( ( hrtime( true ) - $start_time ) / 1000 );
-		$time_to_sleep_in_microseconds = ( 60 / $requests_per_minute * $concurrent_batches * 1000000 ) - $time_elapsed_in_microseconds;
+		$time_to_sleep_in_microseconds = int( ( 60 / $requests_per_minute * $concurrent_batches * 1000000 ) - $time_elapsed_in_microseconds );
 		if ( $time_to_sleep_in_microseconds > 0 ) {
 			// Go to sleep
 			usleep( $time_to_sleep_in_microseconds );


### PR DESCRIPTION
Force sleep time to be int instead of float to suppress deprecation warning

The function usleep() requires the sleep time parameter to an integer number. For now - after the calculations - the sleep time can be a float number. When passing a float number, when integer is expected, PHP 8 will produce a deprecated warning. Even though this is not a fatal error, it is causing error log flooding.

Example of deprecation warnings:

```
PHP Deprecated:  Implicit conversion from float 429482.6666666666 to int loses precision in /woocommerce-custobar/classes/sync-classes/abstract-data-sync.php on line 108
PHP Deprecated:  Implicit conversion from float 440342.6666666666 to int loses precision in /woocommerce-custobar/classes/sync-classes/abstract-data-sync.php on line 108
```